### PR TITLE
feat: extract type from binding and delimiter option for csv

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,22 +19,25 @@ pub struct AppOptions {
     /// whether to provide the output in csv (if not a table will be displayed)
     #[clap(long)]
     pub csv: bool,
-    // whether to wait for input after printing the result (useful for executing in a volatile terminal)
+    /// define delimiter for csv
+    #[clap(short, long, default_value = ",")]
+    pub delimiter: char,
+    /// whether to wait for input after printing the result (useful for executing in a volatile terminal)
     #[clap(short, long)]
     pub block: bool,
-    // the dimension along which to sort the results
+    /// the dimension along which to sort the results
     #[clap(short, long, arg_enum, default_value = "binding")]
     pub sort_dim: SortDimensions,
-    // if specified then only bindings of this category will be shown
+    /// if specified then only bindings of this category will be shown
     #[clap(short, long)]
     pub exclusive_category: Option<String>,
-    // if specified then prints a table with the available categories
+    /// if specified then prints a table with the available categories
     #[clap(long)]
     pub print_categories: bool,
 }
 
 pub fn parse_cli_arguments() -> AppOptions {
-    let args =  AppOptions::parse();
+    AppOptions::parse()
 
     // dbg!(&opts.config_path);
     // dbg!(&opts.csv);
@@ -42,5 +45,4 @@ pub fn parse_cli_arguments() -> AppOptions {
     // dbg!(&opts.sort_dim);
     // dbg!(&opts.exclusive_category);
     // dbg!(&opts.print_categories);
-    return args
 }

--- a/src/config_reader.rs
+++ b/src/config_reader.rs
@@ -90,7 +90,7 @@ fn get_list_of_i3bindings_from_content(
                 "bindcode" => "Code",
                 _ => "Unknown",
             };
-            let _run_type = match caps.name("type") {
+            let run_type = match caps.name("type") {
                 None => "",
                 _ => caps.name("type").unwrap().as_str()
             };
@@ -98,7 +98,7 @@ fn get_list_of_i3bindings_from_content(
                 category: last_category.to_string(),
                 binding_type: binding_type.to_string(),
                 binding: caps.name("binding").unwrap().as_str().to_string(),
-                runtype: _run_type.to_string(),
+                runtype: run_type.to_string(),
                 command: caps.name("command").unwrap().as_str().to_string(),
             });
         }

--- a/src/config_reader.rs
+++ b/src/config_reader.rs
@@ -15,6 +15,7 @@ pub struct I3Binding {
     pub category: String,
     pub binding_type: String,
     pub binding: String,
+    pub runtype: String,
     pub command: String,
 }
 
@@ -65,9 +66,9 @@ fn get_list_of_i3bindings_from_content(
     let mut last_category = "default";
     let mut bindings: Vec<I3Binding> = Vec::new();
 
-    // TODO: "Exec" modifiers are currently being added as part of the command
+    // Binding type modifiers being extracted and added to the table
     let capture_exec =
-        Regex::new(r"(?P<binding_type>bind\w+) (?P<binding>(\w|\$|\+)+) (exec )?(?P<command>.+)")
+        Regex::new(r"(?P<binding_type>bind\w+) (?P<binding>(\w|\$|\+)+) (?:(--release) )?(?P<type>(mode|exec|split|focus|move))? (?P<command>.+)")
             .unwrap();
     let capture_category = Regex::new(r".*(C|c)ategory: (?P<category>.+)").unwrap();
 
@@ -89,10 +90,15 @@ fn get_list_of_i3bindings_from_content(
                 "bindcode" => "Code",
                 _ => "Unknown",
             };
+            let _run_type = match caps.name("type") {
+                None => "",
+                _ => caps.name("type").unwrap().as_str()
+            };
             bindings.push(I3Binding {
                 category: last_category.to_string(),
                 binding_type: binding_type.to_string(),
                 binding: caps.name("binding").unwrap().as_str().to_string(),
+                runtype: _run_type.to_string(),
                 command: caps.name("command").unwrap().as_str().to_string(),
             });
         }

--- a/src/drawers/csv_drawer.rs
+++ b/src/drawers/csv_drawer.rs
@@ -2,9 +2,9 @@ use crate::config_reader::I3Binding;
 use std::collections::HashMap;
 use std::io;
 
-pub fn draw(bindings: HashMap<String, Vec<I3Binding>>) {
+pub fn draw(bindings: HashMap<String, Vec<I3Binding>>, delimiter: char) {
     let mut wtr = csv::WriterBuilder::new()
-        .delimiter(b',')
+        .delimiter(delimiter as u8)
         .quote_style(csv::QuoteStyle::NonNumeric)
         .from_writer(io::stdout());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     if opts.print_categories {
         println!("Categories: {:?}", bindings.keys());
     } else if opts.csv {
-        drawers::csv_drawer::draw(bindings);
+        drawers::csv_drawer::draw(bindings, opts.delimiter);
     } else {
         let table = table_adapter::build_table_from_bindings(bindings);
         drawers::table_drawer::draw(table);

--- a/src/table_adapter.rs
+++ b/src/table_adapter.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 pub fn build_table_from_bindings(mut bindings_map: HashMap<String, Vec<I3Binding>>) -> Table {
     // draw table
     let mut main_table = Table::new();
-    main_table.set_titles(row!["Category", "Actual Binding"]);
+    main_table.set_titles(row!["Category", "Actual Binding", "Binding mode"]);
 
     let mut sorted_vec: Vec<_> = bindings_map.iter_mut().collect();
     sorted_vec.sort_by(|a, b| a.0.cmp(b.0));
@@ -21,10 +21,17 @@ pub fn build_table_from_bindings(mut bindings_map: HashMap<String, Vec<I3Binding
                 acc.add_row(row![e.binding_type, e.binding, e.command]);
                 acc
             });
+        let mut type_table = bindings_for_category
+            .iter()
+            .fold(Table::new(), |mut acc, e| {
+                acc.add_row(row![e.runtype]);
+                acc
+            });
 
         category_table.set_format(*prettytable::format::consts::FORMAT_CLEAN);
+        type_table.set_format(*prettytable::format::consts::FORMAT_CLEAN);
 
-        main_table.add_row(row![category, category_table]);
+        main_table.add_row(row![category, category_table, type_table]);
     }
 
     main_table


### PR DESCRIPTION
I add two feature that I would like to have
- extract binding type from bindsym e.g. |exec|mode|split|move...
- add delimiter option for csv file

which would be to filter out the specifics command that you are looking for
